### PR TITLE
gltf: node reordering, cameras

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ mint = "0.5"
 bitflags = "1.0"
 bytemuck = { version = "1.4", features = ["derive"] }
 glam = "0.18"
-gltf = { version = "0.16", features = ["utils"], optional = true }
+gltf = { version = "0.16", features = ["names", "utils"], optional = true }
 fxhash = "0.2"
 log = "0.4"
 obj = { version = "0.10", optional = true }

--- a/baryon-core/Cargo.toml
+++ b/baryon-core/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 # public
 bytemuck = "1.4"
-hecs = "0.7"
+hecs = "=0.7.1"
 mint = "0.5"
 raw-window-handle = "0.3"
 wgpu = "0.11"

--- a/baryon-core/src/space.rs
+++ b/baryon-core/src/space.rs
@@ -60,7 +60,7 @@ impl<T> super::ObjectBuilder<'_, T> {
 
     pub fn orientation_around(&mut self, axis: mint::Vector3<f32>, angle_deg: f32) -> &mut Self {
         self.node.local.orientation =
-            glam::Quat::from_axis_angle(axis.into(), angle_deg * DEGREES_TO_RADIANS);
+            glam::Quat::from_axis_angle(axis.into(), angle_deg.to_radians());
         self
     }
 
@@ -116,21 +116,20 @@ impl super::Node {
 
     pub fn get_rotation(&self) -> (mint::Vector3<f32>, f32) {
         let (axis, angle) = self.local.orientation.to_axis_angle();
-        (axis.into(), angle * RADIANS_TO_DEGREES)
+        (axis.into(), angle.to_degrees())
     }
     pub fn set_rotation(&mut self, axis: mint::Vector3<f32>, angle_deg: f32) {
-        self.local.orientation =
-            glam::Quat::from_axis_angle(axis.into(), angle_deg * DEGREES_TO_RADIANS);
+        self.local.orientation = glam::Quat::from_axis_angle(axis.into(), angle_deg.to_radians());
     }
     pub fn pre_rotate(&mut self, axis: mint::Vector3<f32>, angle_deg: f32) {
         self.local.orientation = self.local.orientation
-            * glam::Quat::from_axis_angle(axis.into(), angle_deg * DEGREES_TO_RADIANS);
+            * glam::Quat::from_axis_angle(axis.into(), angle_deg.to_radians());
     }
     pub fn post_rotate(&mut self, axis: mint::Vector3<f32>, angle_deg: f32) {
         let other = Space {
             position: glam::Vec3::ZERO,
             scale: 1.0,
-            orientation: glam::Quat::from_axis_angle(axis.into(), angle_deg * DEGREES_TO_RADIANS),
+            orientation: glam::Quat::from_axis_angle(axis.into(), angle_deg.to_radians()),
         };
         self.local = other.combine(&self.local);
     }
@@ -212,9 +211,6 @@ impl Default for Camera {
     }
 }
 
-const DEGREES_TO_RADIANS: f32 = std::f32::consts::PI / 180.0;
-const RADIANS_TO_DEGREES: f32 = 180.0 / std::f32::consts::PI;
-
 impl Camera {
     pub fn projection_matrix(&self, aspect: f32) -> mint::ColumnMatrix4<f32> {
         let matrix = match self.projection {
@@ -230,7 +226,7 @@ impl Camera {
                 )
             }
             Projection::Perspective { fov_y } => {
-                let fov = fov_y * DEGREES_TO_RADIANS;
+                let fov = fov_y.to_radians();
                 if self.depth.end == f32::INFINITY {
                     assert!(self.depth.start.is_finite());
                     glam::Mat4::perspective_infinite_rh(fov, aspect, self.depth.start)

--- a/examples/load-gltf.rs
+++ b/examples/load-gltf.rs
@@ -5,34 +5,17 @@ fn main() {
     let mut context = pollster::block_on(baryon::Context::init().build(&window));
     let mut scene = baryon::Scene::new();
 
-    let camera = baryon::Camera {
-        projection: baryon::Projection::Perspective { fov_y: 45.0 },
-        depth: 1.0..100.0,
-        node: scene
-            .add_node()
-            .position([1f32, 2.0, 3.0].into())
-            .look_at([0.0, 0.8, 0.0].into(), [0f32, 1.0, 0.0].into())
-            .build(),
-        background: baryon::Color(0xFF203040),
-    };
-
     let node = scene.add_node().build();
-    let _ = baryon::asset::load_gltf(
+    let module = baryon::asset::load_gltf(
         format!(
-            "{}/examples/assets/Duck/Duck.gltf",
+            //"{}/examples/assets/Duck/Duck.gltf",
+            "{}/../rendering-demo-scenes/pbr-test/pbr-test.glb",
             env!("CARGO_MANIFEST_DIR")
         ),
         &mut scene,
         node,
         &mut context,
     );
-
-    let _point_light = scene
-        .add_point_light()
-        .position([3.0, 3.0, 3.0].into())
-        .color(baryon::Color(0xFFFFFFFF))
-        .intensity(2.0)
-        .build();
 
     let mut pass = baryon::pass::Real::new(
         &baryon::pass::RealConfig {
@@ -47,8 +30,8 @@ fn main() {
             context.resize(width, height);
         }
         Event::Draw => {
-            scene[node].pre_rotate([0.0, 1.0, 0.0].into(), 1.0);
-            context.present(&mut pass, &scene, &camera);
+            let camera = module.cameras.find("Camera").unwrap();
+            context.present(&mut pass, &scene, camera);
         }
         _ => {}
     })


### PR DESCRIPTION
Closes #10
Also changes `load-gltf` example to load the "pbr-test" from https://github.com/aclysma/rendering-demo-scenes, but the file itself is not included, blocked on https://github.com/aclysma/rendering-demo-scenes/issues/3